### PR TITLE
Set default PISE vers to `0.27.0` for `v1` of this action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0 (230830)
+
+Set default PISE version to `0.27.0`, and add documentation stating that
+`0.27.x` is latest compatible for `v1` of this action.
+
 ## 1.0.0 (221217)
 
 First version!

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ example to check on pushes and pull-requests that the repo at least builds.
 
     # PISE version to use when building. This is the tag for the
     # `proofscape/pise` docker image we use to perform the build.
-    # Default: latest
+    # Cannot be later than `0.27.x` when using `v1` of this
+    # `pfsc-repo-build-action`. To use PISE versions later than `0.27.x`,
+    # switch to `v2` (or later) of `pfsc-repo-build-action`.
+    # Default: 0.27.0
     pise-vers: ''
 
     # Working directory, i.e. space in which to do things like checkout the

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,10 @@ inputs:
     description: >
       PISE version to use when building. This is the tag for the
       `proofscape/pise` docker image we use to perform the build.
-      Default: latest
-    default: latest
+      Cannot be later than `0.27.x` when using `v1` of this
+      `pfsc-repo-build-action`. To use PISE versions later than `0.27.x`,
+      switch to `v2` (or later) of `pfsc-repo-build-action`.
+    default: 0.27.0
   workspace:
     description: >
       Working directory, i.e. space in which to do things like checkout the


### PR DESCRIPTION
Starting with PISE `v0.28.0`, the build command in this action will be incorrect, since it calls for the `-r` (recursive) option, which is no longer supported.

Therefore we should cap `v1` of this action at PISE `0.27.x`, and release a `v2` that continues to use `latest` for the default PISE version.