### PR TITLE
Version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ later.
 A `clean` option is added. (Potentially useful for repeated builds within a
 single job.)
 
+The input type for `container-persist` is changed to `boolean`.
+
 ## 1.1.0 (230830)
 
 Set default PISE version to `0.27.0`, and add documentation stating that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.0.0 (230830)
+
+In version 2, the minimum PISE version is `0.28.0`, and the default is
+`latest`. The build command is updated to work with PISE versions `0.28.0` and
+later.
+
+A `clean` option is added. (Potentially useful for repeated builds within a
+single job.)
+
 ## 1.1.0 (230830)
 
 Set default PISE version to `0.27.0`, and add documentation stating that

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Proofscape repo build action
+# Proofscape repo build action `v2`
 
 This action builds a Proofscape content repo. It can be used in a workflow, for
 example to check on pushes and pull-requests that the repo at least builds.
@@ -6,7 +6,7 @@ example to check on pushes and pull-requests that the repo at least builds.
 ## Usage
 
 ```yaml
-- uses: proofscape/pfsc-repo-build-action@v1
+- uses: proofscape/pfsc-repo-build-action@v2
   with:
     # The owner/reponame of the Proofscape content repo to be built.
     # Default: ${{ github.repository }}
@@ -17,13 +17,17 @@ example to check on pushes and pull-requests that the repo at least builds.
     # the workflow, or the default branch if no such event.
     # Default: WIP
     content-vers: ''
+    
+    # Whether to do a clean build, ensuring all modules are re-read
+    # from source.
+    # Default: false
+    clean: ''
 
     # PISE version to use when building. This is the tag for the
     # `proofscape/pise` docker image we use to perform the build.
-    # Cannot be later than `0.27.x` when using `v1` of this
-    # `pfsc-repo-build-action`. To use PISE versions later than `0.27.x`,
-    # switch to `v2` (or later) of `pfsc-repo-build-action`.
-    # Default: 0.27.0
+    # Must be `0.28.0` or later. To use earlier versions of PISE, must use
+    # `v1` of this `pfsc-repo-build-action`.
+    # Default: latest
     pise-vers: ''
 
     # Working directory, i.e. space in which to do things like checkout the
@@ -72,13 +76,13 @@ example to check on pushes and pull-requests that the repo at least builds.
 ## Build at WIP
 
 ```yaml
-- uses: proofscape/pfsc-repo-build-action@v1
+- uses: proofscape/pfsc-repo-build-action@v2
 ```
 
 ## Build at a numbered version
 
 ```yaml
-- uses: proofscape/pfsc-repo-build-action@v1
+- uses: proofscape/pfsc-repo-build-action@v2
   with:
     content-vers: v3.1.4
 ```
@@ -86,7 +90,7 @@ example to check on pushes and pull-requests that the repo at least builds.
 ## Examine the build results
 
 ```yaml
-- uses: proofscape/pfsc-repo-build-action@v1
+- uses: proofscape/pfsc-repo-build-action@v2
   with:
     container-persist: yes
 - working-directory: proofscape/build/gh/${{ github.repository }}/WIP

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ example to check on pushes and pull-requests that the repo at least builds.
     # Default: pfsc-gdb
     gdb-volume: ''
 
-    # If "yes", keep the PISE container running after completing.
-    # Default: no
+    # Whether to keep the PISE container running after completing.
+    # Default: false
     container-persist: ''
 
     # The name of the PISE docker container in which the build takes place.
@@ -92,7 +92,7 @@ example to check on pushes and pull-requests that the repo at least builds.
 ```yaml
 - uses: proofscape/pfsc-repo-build-action@v2
   with:
-    container-persist: yes
+    container-persist: true
 - working-directory: proofscape/build/gh/${{ github.repository }}/WIP
   run: |
     docker exec pise bash -c "\

--- a/action.yml
+++ b/action.yml
@@ -57,9 +57,9 @@ inputs:
     default: pfsc-gdb
   container-persist:
     description: >
-      If "yes", keep the PISE container running after completing.
-      Default "no"
-    default: no
+      Whether to keep the PISE container running after completing.
+    type: boolean
+    default: false
   container-name:
     description: >
       The name of the PISE docker container in which the build takes place.

--- a/action.yml
+++ b/action.yml
@@ -15,14 +15,19 @@ inputs:
       If unspecified, build @WIP, meaning the reference or SHA that triggered
       the workflow, or the default branch if no such event.
     default: WIP
+  clean:
+    description: >
+      Whether to do a clean build, ensuring all modules are re-read from
+      source.
+    type: boolean
+    default: false
   pise-vers:
     description: >
       PISE version to use when building. This is the tag for the
       `proofscape/pise` docker image we use to perform the build.
-      Cannot be later than `0.27.x` when using `v1` of this
-      `pfsc-repo-build-action`. To use PISE versions later than `0.27.x`,
-      switch to `v2` (or later) of `pfsc-repo-build-action`.
-    default: 0.27.0
+      Must be `0.28.0` or later. To use earlier versions of PISE, must use
+      `v1` of this `pfsc-repo-build-action`.
+    default: latest
   workspace:
     description: >
       Working directory, i.e. space in which to do things like checkout the
@@ -140,8 +145,8 @@ runs:
           -e FLASK_APP=pfsc \
           -w /home/pfsc/proofscape/src/pfsc-server \
           ${{inputs.container-name}} bash -c "\
-            flask pfsc build --auto-deps \
-              -rv ${{steps.conf.outputs.content-libpath}} \
+            flask pfsc build --auto-deps ${{ inputs.clean && '--clean' || '' }} \
+              -v ${{steps.conf.outputs.content-libpath}} \
               -t ${{inputs.content-vers}} \
           "
     # Stop the container (optionally)


### PR DESCRIPTION
Develop a `v2` for this action, to work with PISE `v0.28.0` and up, where CLI build takes a different set of options than before.